### PR TITLE
Storage address load from linkerscript

### DIFF
--- a/linkerscript.ld
+++ b/linkerscript.ld
@@ -112,6 +112,17 @@ SECTIONS
         PROVIDE(__fini_array_end = .);
     } > rom
 
+    .profile (NOLOAD) :
+    {
+        /* provide the start and the end of the profile section */
+        PROVIDE(__profiles_start = .);
+
+        /* mark the whole section as filled with data */
+        . = . + LENGTH(profiles);
+
+        PROVIDE(__profiles_end = .);
+    } > profiles
+
     /* Stack segment */
     .stack (NOLOAD) :
     {

--- a/linkerscript.ld
+++ b/linkerscript.ld
@@ -18,6 +18,10 @@ Memories definitions
 MEMORY
 {
     rom (rx) : org = 0x00000000 + 8k, len = 256k - 8k - 32k
+    /* Note: The profiles need to be sector alligned. The 
+       storage erases the whole sector and writes the entries
+       back if we changed something. All other data in this
+       sector will be lost on changing the entries */
     profiles (r) : org = 0x00000000 + 256k - 32k, len = 32k
     ram (rwx) : org = 0x10000000, len = 16k
     ram1 (rwx) : org = 0x2007C000, len = 16k

--- a/main.cpp
+++ b/main.cpp
@@ -148,7 +148,7 @@ int main() {
     constexpr static uint32_t key_end = 0x40000;
 
     // using for the storage
-    using storage = storage::storage<flash, key_start, key_end>;
+    using storage = storage::storage<flash>;
 
     // create the popup first as some other screens use it
     menu::numeric_popup<fb_t> numeric_popup = {};

--- a/main.cpp
+++ b/main.cpp
@@ -142,11 +142,6 @@ int main() {
     // using for writing to flash
     using flash = target::io::flash;
 
-    // the range where we store the keys is 0x38000 - 0x40000
-    // TODO: use the region from the linkerscript
-    constexpr static uint32_t key_start = 0x38000;
-    constexpr static uint32_t key_end = 0x40000;
-
     // using for the storage
     using storage = storage::storage<flash>;
 

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,6 @@ More pictures can be found [here](./img/)
 * support for different intervals
 * support for 8 digit keys
 * add support for more than 32 profiles (needs a rework if more profiles are required. The profiles are copied to ram and there is not enough for more at the moment. If we leave them in flash we can store a lot more)
-* support for reading the profile locations from the linkerscript instead of hardcoded
 * rework the calibration and time settings screens
 
 ### Compiling

--- a/storage.hpp
+++ b/storage.hpp
@@ -7,7 +7,14 @@
 #include <klib/string.hpp>
 
 extern "C" {
+    // Start of the profile section. Definition is done in the 
+    // linkerscript. Only the address of the variable should be used. The
+    // address points to the correct location of the variable
     extern uint32_t __profiles_start; 
+
+    // End of the profile section. Definition is done in the 
+    // linkerscript. Only the address of the variable should be used. The
+    // address points to the correct location of the variable
     extern uint32_t __profiles_end; 
 }
 

--- a/storage.hpp
+++ b/storage.hpp
@@ -6,6 +6,11 @@
 #include <klib/dynamic_array.hpp>
 #include <klib/string.hpp>
 
+extern "C" {
+    extern uint32_t __profiles_start; 
+    extern uint32_t __profiles_end; 
+}
+
 namespace storage {
     enum class digit: uint8_t {
         digits_6 = 6,
@@ -53,7 +58,7 @@ namespace storage {
      * @brief Storage class that reads the entries
      * 
      */
-    template <typename Flash, uint32_t Start, uint32_t End>
+    template <typename Flash>
     class storage {
     public:
         // the max amount of entries we support for now
@@ -63,6 +68,9 @@ namespace storage {
         // array to store all the entries
         static inline klib::dynamic_array<entry, max_entries> entries = {};
 
+        // start address used in writing
+        static inline uint32_t start_address = 0xffffffff;
+
     public:
         /**
          * @brief Read the memory and add them to the entries array
@@ -71,11 +79,13 @@ namespace storage {
          * @param end 
          * @param key 
          */
-        static void init(const std::span<uint8_t> key) {
-            uint32_t address = Start;
+        static void init(const std::span<uint8_t> key, const uint32_t start, const uint32_t end) {
+            // update the start address and set the address we should
+            // start reading from
+            uint32_t address = start_address = start;
 
             // get all the entries
-            for (uint32_t i = 0; (i < max_entries) && ((address + sizeof(entry)) < End); i++) {
+            for (uint32_t i = 0; (i < max_entries) && ((address + sizeof(entry)) < end); i++) {
                 // TODO: decrypt the keys here
                 const auto& e = *reinterpret_cast<const entry*>(address);
 
@@ -110,8 +120,14 @@ namespace storage {
          * 
          */
         static void write() {
+            // make sure we are initialized
+            if (start_address == 0xffffffff) {
+                // do not write if the start address is wrong
+                return;
+            }
+
             // erase the sector
-            Flash::erase(Flash::erase_mode::sector, Start);
+            Flash::erase(Flash::erase_mode::sector, start_address);
 
             // write in 1024 byte chunks
             for (uint32_t i = 0; i < ((max_entries * sizeof(entry)) / 1024); i++) {
@@ -120,7 +136,7 @@ namespace storage {
                 };
 
                 // write the new data
-                Flash::write(Start + (i * 1024), p);
+                Flash::write(start_address + (i * 1024), p);
             }
         }
     };

--- a/ui/splash.hpp
+++ b/ui/splash.hpp
@@ -2,6 +2,8 @@
 
 #include <klib/graphics/bitmap.hpp>
 
+#include <storage.hpp>
+
 #include "screen.hpp"
 
 namespace menu {
@@ -90,7 +92,10 @@ namespace menu {
             Rtc::init();
 
             // init the storage for all the keys
-            Storage::init({});
+            Storage::init({}, 
+                reinterpret_cast<uint32_t>(&__profiles_start), 
+                reinterpret_cast<uint32_t>(&__profiles_end)
+            );
 
             // init the usb driver + device
             Usb::init();


### PR DESCRIPTION
Changed storage to use addresses provided in the linkerscript. This should make it easier to change to a MCU with less memory